### PR TITLE
Fix documentation inaccuracies

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -8,7 +8,7 @@ All commands are sub-commands of `/aaf`.
 
 ### /aaf accounts \<ip\>
 
-**Description:** Lists all player accounts that have logged in from the specified IP address.  
+**Description:** Lists all player accounts that have logged in from the specified IP address, along with each account's login count and first/last login timestamps. Banned players are highlighted in red. Each result is clickable and runs `/aaf ips` for that account.  
 **Permission:** `aaf.accounts`  
 **Usage:** `/aaf accounts <ip>`  
 **Example:** `/aaf accounts 192.168.1.1`
@@ -17,7 +17,7 @@ All commands are sub-commands of `/aaf`.
 
 ### /aaf ips \<player\>
 
-**Description:** Lists all IP addresses that the specified player has logged in from.  
+**Description:** Lists all IP addresses that the specified player has logged in from, along with each address's login count and first/last login timestamps. IPs that are banned via Bukkit's IP-ban list are highlighted in red. Each result is clickable and runs `/aaf accounts` for that IP.  
 **Permission:** `aaf.ips`  
 **Usage:** `/aaf ips <player>`  
 **Example:** `/aaf ips Steve`

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -75,7 +75,13 @@ database:
 
 **Type:** list of UUIDs  
 **Default:** *(example UUIDs — replace with your own)*  
-**Description:** A list of player UUIDs that will receive in-game notifications when a player joins who has been detected as a potential alternate account. Remove all entries or leave the list empty to disable notifications.
+**Description:** A list of player UUIDs that will be notified when a player joins for the *first time* from a given IP and that IP already has at least one other associated account on record. Notifications are not re-sent for subsequent joins from the same IP. Remove all entries or leave the list empty to disable notifications.
+
+Notification delivery depends on which optional plugins are installed:
+
+- If the **Mailboxes** plugin is present, notifications are delivered as mailbox messages.
+- Otherwise, if the **RPKit** notification library is present, notifications go through the RPKit notification system.
+- If neither is installed, notifications fall back to a plain in-game chat message sent to the recipient if they are online.
 
 **Example:**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Work items are tracked as [GitHub issues](https://github.com/Dans-Plugins/Altern
 
 ### Milestones
 
-Issues are grouped into [milestones](https://github.com/Dans-Plugins/AlternateAccountFinder/milestones) representing upcoming releases.
+Issues may be grouped into [milestones](https://github.com/Dans-Plugins/AlternateAccountFinder/milestones) when work is being planned for a specific release.
 
 ## Making Changes
 
@@ -47,9 +47,11 @@ Issues are grouped into [milestones](https://github.com/Dans-Plugins/AlternateAc
 8. Open a pull request against `main`, link the related issue with `#<number>`.
 9. Address review feedback.
 
-### Language Files
+### User-Facing Strings
 
-Update `src/main/resources/lang/` for any user-facing string changes.
+User-facing strings (command output, error messages, notification text) are
+currently hardcoded in the Java source under `src/main/java/`. There is no
+separate language-file layer yet — change the strings at their use site.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ You can view the bStats page for the plugin [here](https://bstats.org/plugin/buk
 
 - [Known Bugs](https://github.com/Dans-Plugins/AlternateAccountFinder/issues?q=is%3Aopen+is%3Aissue+label%3Abug)
 - [Planned Features](https://github.com/Dans-Plugins/AlternateAccountFinder/issues?q=is%3Aopen+is%3Aissue+label%3AEpic)
-- [Planned Improvements](https://github.com/Dans-Plugins/AlternateAccountFinder/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement)
+- [Planned Improvements](https://github.com/Dans-Plugins/AlternateAccountFinder/issues?q=is%3Aopen+is%3Aissue+label%3Aimprovement)
 
 ## Changelog
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -33,7 +33,7 @@ Example:
 /aaf accounts 192.168.1.1
 ```
 
-The plugin will list every player name that has connected from that IP.
+The plugin will list every player name that has connected from that IP, along with each account's login count and first/last login timestamps. Banned players are highlighted in red. Click any result to run `/aaf ips` for that account.
 
 ### Finding all IP addresses used by a player
 
@@ -48,6 +48,8 @@ Example:
 ```
 /aaf ips Steve
 ```
+
+Each result shows the IP, login count, and first/last login timestamps. IPs that are banned via Bukkit's IP-ban list are highlighted in red. Click any result to run `/aaf accounts` for that IP.
 
 ### Finding suspected alternate accounts for a player
 


### PR DESCRIPTION
## Summary

Audit pass over the markdown docs added in #59, verifying each claim against the actual code on `main`. Five small fixes:

- **CONTRIBUTING.md** pointed at `src/main/resources/lang/` for user-facing string changes — that directory doesn't exist; strings are hardcoded in Java. Rewrote the section.
- **README.md** Roadmap link used the label `enhancement`, which isn't in the repo's label set. The actual label is `improvement`. Fixed.
- **CONFIG.md** `notify-users` description was too narrow. Notifications only fire on the *first* login from a given `(player, IP)` pair, and only when that IP already has another account on record (see `PlayerJoinListener.onPlayerJoin`). Also clarified that delivery routes through Mailboxes → RPKit → in-game chat depending on which optional plugins are installed.
- **COMMANDS.md** and **USER_GUIDE.md** only documented the click-to-`/aaf ips` interaction on `/aaf alts`. Both `/aaf accounts` and `/aaf ips` results are also clickable. Documented that, plus the login-count and first/last-login columns each command surfaces.
- **CONTRIBUTING.md** milestones section said issues are grouped into milestones "representing upcoming releases", but the only existing milestone (Sprint 1) is fully closed. Softened the wording.

No code changes, no semantic behavior changes.

## Test plan
- [ ] `./gradlew clean build` still passes (docs-only — no functional impact expected).
- [ ] Spot-check the rendered markdown for the five files above on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)