### PR TITLE
Document IP encryption changes in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Security
+
+- IP addresses are now encrypted at rest using deterministic AES-256 (ECB mode) instead of being stored as plaintext, so lookups (accounts-by-IP, alt detection) still work while the raw address is no longer readable directly from the database (see [#45](https://github.com/Dans-Plugins/AlternateAccountFinder/issues/45)). The encryption key is generated on first startup and stored in the plugin's data folder with `0600` permissions.
+- Existing plaintext IP addresses from installs predating this change are automatically migrated to the encrypted format on plugin startup, with a completion marker so the migration only runs once (see [#46](https://github.com/Dans-Plugins/AlternateAccountFinder/issues/46)).
+
 ### Removed
 
 - Removed the `/aaf ips` sub-command and its `aaf.ips` permission. Exposing the list of IP addresses a player has used was a privacy concern (see [#44](https://github.com/Dans-Plugins/AlternateAccountFinder/issues/44)). Click/hover actions on `/aaf accounts` and `/aaf alts` results no longer invoke `/aaf ips`.


### PR DESCRIPTION
## Summary
- PR #58 added deterministic AES-256 (ECB) encryption for stored IP addresses, plus automatic migration of legacy plaintext IPs, but the `[Unreleased]` section of CHANGELOG.md was never updated to document it.
- Adds a `### Security` entry describing both changes, referencing #45 and #46 for traceability.
- This cycle is a Stage A documentation-accuracy sweep (per the dev-loop skill): the open-issue backlog for this repo consisted only of #46 (support for encrypting old save files, already resolved by PR #58 — closed this cycle) and #47 (a bodyless "Encryption Epic" tracking issue, left open with a comment for a human to confirm scope, since closing an epic isn't a call this cycle should make unilaterally). No other doc-source-of-truth drift was found across `plugin.yml`, `COMMANDS.md`, `USER_GUIDE.md`, `CONFIG.md`, `config.yml`, or `README.md` — all match current source.
- Separately, `.github/copilot-instructions.md` has real drift (still lists the removed `AafIpsCommand`, is missing the `encryption/` package, and says "Test framework: Not yet configured" even though JUnit 5 is wired up in `build.gradle` with an existing test under `src/test/java/`). Per this skill's rules, editing agent-loaded config requires separate human authorization, so this was **not** fixed here — filing a follow-up issue on the project repo instead.

## Test plan
- [x] `./gradlew compileJava` — compiles cleanly (docs-only change; this is a sanity check, not functional verification)
- [x] Read CHANGELOG.md end-to-end after the edit to confirm formatting matches existing entries

Closes #46 (already closed directly this cycle, not via merge — referenced here for traceability)

<!-- gardener-tend-dispatch -->