### PR TITLE
Document IP encryption key management in the user-facing docs

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -2,6 +2,8 @@
 
 All options are set in `plugins/AlternateAccountFinder/config.yml`. The file is created automatically on first run.
 
+The plugin also writes two non-configuration files into the same folder — see [Files in the data folder](#files-in-the-data-folder) at the end of this guide.
+
 ---
 
 ## database.url
@@ -89,3 +91,24 @@ Notification delivery depends on which optional plugins are installed:
 notify-users:
   - 0a9fa342-3139-49d7-8acb-fcf4d9c1f0ef
 ```
+
+---
+
+## Files in the data folder
+
+`plugins/AlternateAccountFinder/` holds two files besides `config.yml`. Neither is configuration, and neither should be edited by hand.
+
+| File | Created | Purpose |
+|------|---------|---------|
+| `ip-encryption.key` | First startup | The AES-256 key used to encrypt stored IP addresses. Restricted to owner read/write (`600`) on POSIX systems. **Must be backed up with your database** — see [IP Address Encryption](USER_GUIDE.md#ip-address-encryption). |
+| `ip-migration-v2.complete` | After the plaintext-to-encrypted migration finishes | A marker that records the one-time migration of pre-existing plaintext IP addresses. While it is present, startup skips the migration scan entirely. |
+
+### ip-encryption.key
+
+Losing this file means every IP address already stored becomes permanently unreadable, and the plugin will generate a replacement key and continue running rather than stopping. The [User Guide](USER_GUIDE.md#back-up-the-key-file) describes exactly which lookups stop working. If the file is present but not exactly 32 bytes, the plugin treats it as corrupted and refuses to start — restore it from a backup rather than deleting it.
+
+### ip-migration-v2.complete
+
+On the first startup after upgrading from a version that stored IP addresses as plaintext, the plugin scans every login record and encrypts any address that is still plaintext. It writes this marker once that pass completes with no failures, so later startups skip the scan instead of re-checking every record. If the pass had failures, the marker is not written and the migration is retried on the next startup.
+
+Deleting the marker forces the scan to run again on the next startup. Do not delete it as a routine measure, and in particular do not delete it if `ip-encryption.key` has been lost or replaced: the scan identifies plaintext by attempting to decrypt each stored value with the current key, so addresses encrypted under a key that is no longer present would be misread as plaintext and encrypted a second time.

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -100,15 +100,15 @@ notify-users:
 
 | File | Created | Purpose |
 |------|---------|---------|
-| `ip-encryption.key` | First startup | The AES-256 key used to encrypt stored IP addresses. Restricted to owner read/write (`600`) on POSIX systems. **Must be backed up with your database** — see [IP Address Encryption](USER_GUIDE.md#ip-address-encryption). |
-| `ip-migration-v2.complete` | After the plaintext-to-encrypted migration finishes | A marker that records the one-time migration of pre-existing plaintext IP addresses. While it is present, startup skips the migration scan entirely. |
+| `ip-encryption.key` | First startup | The AES-256 key used to encrypt stored IP addresses. Set to owner read/write (`600`) on POSIX systems at the moment the plugin generates it. **Must be backed up with your database** — see [IP Address Encryption](USER_GUIDE.md#ip-address-encryption). |
+| `ip-migration-v2.complete` | First startup, once the plaintext-to-encrypted scan completes cleanly | A marker that records the one-time migration of pre-existing plaintext IP addresses. While it is present, startup skips the migration scan entirely. |
 
 ### ip-encryption.key
 
-Losing this file means every IP address already stored becomes permanently unreadable, and the plugin will generate a replacement key and continue running rather than stopping. The [User Guide](USER_GUIDE.md#back-up-the-key-file) describes exactly which lookups stop working. If the file is present but not exactly 32 bytes, the plugin treats it as corrupted and refuses to start — restore it from a backup rather than deleting it.
+Losing this file means every IP address already stored becomes permanently unreadable, and the plugin will generate a replacement key and carry on rather than stopping. The [User Guide](USER_GUIDE.md#back-up-the-key-file) describes exactly which lookups stop working. If the file is present but not exactly 32 bytes, the plugin treats it as corrupted and fails to enable — restore it from a backup rather than deleting it.
 
 ### ip-migration-v2.complete
 
-On the first startup after upgrading from a version that stored IP addresses as plaintext, the plugin scans every login record and encrypts any address that is still plaintext. It writes this marker once that pass completes with no failures, so later startups skip the scan instead of re-checking every record. If the pass had failures, the marker is not written and the migration is retried on the next startup.
+On startup, if this marker is absent, the plugin scans every login record and encrypts any address that is still plaintext. That is what upgrading from a version which stored IP addresses as plaintext needs; on a fresh install the scan simply finds nothing to do. Either way the marker is written once the pass completes with no failures, so later startups skip the scan instead of re-checking every record — which is why the file also appears on installs that never had any plaintext to migrate. If the pass had failures, the marker is not written and the migration is retried on the next startup.
 
 Deleting the marker forces the scan to run again on the next startup. Do not delete it as a routine measure, and in particular do not delete it if `ip-encryption.key` has been lost or replaced: the scan identifies plaintext by attempting to decrypt each stored value with the current key, so addresses encrypted under a key that is no longer present would be misread as plaintext and encrypted a second time.

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -17,7 +17,7 @@ To verify the plugin loaded correctly, run:
 
 You should see a usage message listing the available sub-commands.
 
-On that first startup the plugin also generates an encryption key and prints a warning block about backing it up. Read [IP Address Encryption](#ip-address-encryption) before you go any further — it is the one piece of setup that cannot be repaired after the fact.
+On that first startup the plugin also generates an encryption key and prints a warning block about backing it up. Read [IP Address Encryption](#ip-address-encryption) before you start collecting data you would not want to lose.
 
 ## IP Address Encryption
 
@@ -27,7 +27,9 @@ The plugin encrypts every IP address it stores, so the raw addresses are not rea
 plugins/AlternateAccountFinder/ip-encryption.key
 ```
 
-On Linux and other POSIX systems the plugin restricts this file to owner read/write (`600`) after creating it. On systems without POSIX file permissions (such as Windows) it logs that permission restrictions are unavailable and leaves the file as-is.
+On Linux and other POSIX systems the plugin restricts this file to owner read/write (`600`) at the moment it creates it. On systems without POSIX file permissions (such as Windows) it logs that permission restrictions are unavailable and leaves the file as-is. Permissions are only applied to a key the plugin generates itself — if you restore the file from a backup, check its permissions yourself.
+
+The other files the plugin keeps in that folder are described under [Files in the data folder](CONFIG.md#files-in-the-data-folder) in the Configuration Guide.
 
 ### Back up the key file
 
@@ -40,11 +42,7 @@ If the key file is missing when the server starts, the plugin does not stop — 
 
 There is no way to recover the old addresses without the original key file.
 
-If the key file exists but is not exactly 32 bytes, the plugin treats it as corrupted and refuses to start rather than quietly generating a replacement. Restore the file from a backup instead of deleting it.
-
-### Files in the data folder
-
-Besides `config.yml`, the plugin writes two files into `plugins/AlternateAccountFinder/` that are not configuration and should not be edited by hand. See the [Configuration Guide](CONFIG.md#files-in-the-data-folder) for details.
+If the key file exists but is not exactly 32 bytes, the plugin treats it as corrupted and fails to enable rather than quietly generating a replacement — the server keeps running without it. Restore the file from a backup instead of deleting it.
 
 ## Common Scenarios
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -17,6 +17,35 @@ To verify the plugin loaded correctly, run:
 
 You should see a usage message listing the available sub-commands.
 
+On that first startup the plugin also generates an encryption key and prints a warning block about backing it up. Read [IP Address Encryption](#ip-address-encryption) before you go any further — it is the one piece of setup that cannot be repaired after the fact.
+
+## IP Address Encryption
+
+The plugin encrypts every IP address it stores, so the raw addresses are not readable directly from the database. Encryption uses AES-256 with a single key that is generated on first startup and kept in the plugin's data folder:
+
+```
+plugins/AlternateAccountFinder/ip-encryption.key
+```
+
+On Linux and other POSIX systems the plugin restricts this file to owner read/write (`600`) after creating it. On systems without POSIX file permissions (such as Windows) it logs that permission restrictions are unavailable and leaves the file as-is.
+
+### Back up the key file
+
+**Back up `ip-encryption.key` alongside your database backups, and keep the two together.** The plugin logs a warning block naming the file's full path on every startup, because a database backup without its matching key file is not a usable backup.
+
+If the key file is missing when the server starts, the plugin does not stop — it generates a **new** key and carries on. Addresses stored under the old key cannot be decrypted with the new one, which degrades detection in ways that are easy to miss:
+
+- `/aaf accounts <ip>` no longer finds accounts recorded before the key changed. It encrypts the IP you type with the current key and matches on that, so only logins recorded after the change come back.
+- `/aaf alts <player>` still links accounts to each other *within* each key era, because it compares stored addresses against one another rather than decrypting them. It will not link an account recorded before the key changed to one recorded after, even when both used the same IP.
+
+There is no way to recover the old addresses without the original key file.
+
+If the key file exists but is not exactly 32 bytes, the plugin treats it as corrupted and refuses to start rather than quietly generating a replacement. Restore the file from a backup instead of deleting it.
+
+### Files in the data folder
+
+Besides `config.yml`, the plugin writes two files into `plugins/AlternateAccountFinder/` that are not configuration and should not be edited by hand. See the [Configuration Guide](CONFIG.md#files-in-the-data-folder) for details.
+
 ## Common Scenarios
 
 ### Finding all accounts for a known IP address


### PR DESCRIPTION
## Summary

- Adds an **IP Address Encryption** section to `USER_GUIDE.md`: what is encrypted, where `ip-encryption.key` lives, its `600` permissions on POSIX (and the documented fallback on non-POSIX systems), the backup requirement, and — traced through `LoginRepository` — exactly which lookups degrade if the key is replaced (`/aaf accounts <ip>` stops finding older logins; `/aaf alts` keeps linking accounts *within* each key era but not across one, since it compares stored ciphertext rather than decrypting).
- Adds a **Files in the data folder** section to `CONFIG.md` covering `ip-encryption.key` and `ip-migration-v2.complete`, including the fact that deleting the marker forces a re-scan and must not be done if the key file has been lost.
- Cross-links the two new sections and points at them from the existing "First Steps" and `CONFIG.md` intro.

`IpEncryption` prints a `*** CRITICAL: BACK UP THIS KEY FILE ***` block on every startup, but `grep -i 'encrypt|key file|backup' *.md` hit only the two `CHANGELOG.md` `[Unreleased]` entries — a history of changes, not operational guidance. An admin following the User Guide had no way to learn that a file in the data folder is now as critical as their database backup.

Documentation only — no source, config, or build changes.

Closes #63

## Verification

**Local build anchor: UNVERIFIED — not applicable.** `./gradlew` cannot run in this environment: the only reachable JVM is 21 and Gradle 8.1.1 fails with `BUG! exception in phase 'semantic analysis' ... Unsupported class file major version 65` before reaching any task. This PR modifies no file the build would validate (two `.md` files, zero source changes), so this is the documented not-applicable case rather than a skipped check. CI on this PR's head SHA is the anchor.

No `CHANGELOG.md` entry: this changes documentation, not plugin behavior, and the repo's changelog convention (`[2.0.0]` and `[Unreleased]`) lists functional changes only — PR #61 added the changelog entries for the encryption *feature*; this PR documents it for users. No `README.md` change either, since no new doc file was added to its "Documentation" list.

## Test plan

- [x] Every documented claim traced to source: AES-256 key size and the 32-byte corruption check (`IpEncryption.getOrCreateKey`), `600` permissions and the non-POSIX fallback (`setRestrictivePermissions`), the per-startup warning block naming the absolute path (`logKeyBackupWarning`), new-key-on-missing-file (`getOrCreateKey` → `createNewKey`), marker written only when `failedCount == 0` and the marker short-circuit (`AlternateAccountFinder.migrateExistingIpAddresses` / `writeMigrationMarker`), and the decrypt-probe plaintext detection (`isEncrypted`).
- [x] Lookup-degradation claims traced to the actual queries: `getAddressInfo` and `getLoginCount` encrypt the input with the current key before matching; `getPotentialAlts` self-joins on `record1.ADDRESS = record2.ADDRESS` with no encryption call.
- [x] No real player IP addresses or key material introduced; existing `192.168.1.1` examples are untouched.
- [x] Anchor links resolve: `USER_GUIDE.md#ip-address-encryption`, `USER_GUIDE.md#back-up-the-key-file`, `CONFIG.md#files-in-the-data-folder`.
- [x] Sibling structure preserved: `CONFIG.md`'s per-key `## <key>` sections are untouched and the new section is appended after a `---` rather than posing as a config key; `USER_GUIDE.md` keeps its `##`/`###` nesting.
- [ ] Reviewer sanity-check that the rendered anchors work on GitHub.

## Other findings from this cycle's sweep (filed, not fixed here)

- #64 — `/aaf accounts` tab-completion enumerates every online player's IP, functionally reintroducing what #44 removed. Deferred: changes user-visible behavior and needs a maintainer decision on the intended posture for operators.
- #65 — nullable `Player.getAddress()` dereferenced in the async login paths (NPE on join-then-immediate-disconnect).
- #66 — a malformed UUID in `notify-users` throws and silently drops the remaining recipients.
- #67 — the startup migration double-encrypts existing ciphertext when the key file is lost but the completion marker is absent.

**Skip reasons for the rest of the backlog:** #62 (edit to `.github/copilot-instructions.md` — agent-loaded config, needs explicit human authorization); #47 (Epic — awaiting a human decision on whether encryption scope is fully covered); #64–#67 (all require source changes the local build anchor cannot validate this session, so they were left for a cycle with a working JDK 17; #64 additionally needs a maintainer decision).

<!-- gardener-tend-dispatch -->