### PR TITLE
Add LoginService test coverage against an in-memory H2 database

### DIFF
--- a/src/test/java/com/dansplugins/detectionsystem/logins/LoginServiceTest.java
+++ b/src/test/java/com/dansplugins/detectionsystem/logins/LoginServiceTest.java
@@ -1,0 +1,129 @@
+package com.dansplugins.detectionsystem.logins;
+
+import com.dansplugins.detectionsystem.encryption.IpEncryption;
+import org.flywaydb.core.Flyway;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LoginServiceTest {
+
+    @TempDir
+    File dataFolder;
+
+    private LoginService service;
+    private Connection connection;
+
+    @BeforeEach
+    void setUp() throws SQLException {
+        // Same real-H2, no-mocks setup as LoginRepositoryTest: LoginService is a thin
+        // pass-through, so it is only meaningfully tested against a real repository.
+        String jdbcUrl = "jdbc:h2:mem:" + UUID.randomUUID()
+                + ";MODE=MYSQL;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1";
+
+        Flyway flyway = Flyway.configure()
+                .dataSource(jdbcUrl, "sa", "")
+                .locations("classpath:com/dansplugins/detectionsystem/db/migration")
+                .table("aaf_schema_history")
+                .baselineOnMigrate(true)
+                .baselineVersion("0")
+                .validateOnMigrate(false)
+                .load();
+        flyway.migrate();
+
+        connection = DriverManager.getConnection(jdbcUrl, "sa", "");
+        DSLContext dsl = DSL.using(connection, SQLDialect.H2);
+
+        IpEncryption ipEncryption = new IpEncryption(Logger.getLogger(LoginServiceTest.class.getName()), dataFolder);
+        LoginRepository repository = new LoginRepository(dsl, ipEncryption);
+        service = new LoginService(repository);
+    }
+
+    @AfterEach
+    void tearDown() throws SQLException {
+        connection.close();
+    }
+
+    private InetAddress address(String literal) throws UnknownHostException {
+        return InetAddress.getByName(literal);
+    }
+
+    @Test
+    void saveLoginIsReflectedInAddressInfo() throws UnknownHostException {
+        UUID player = UUID.randomUUID();
+        InetAddress ip = address("192.168.10.1");
+
+        service.saveLogin(player, ip);
+
+        AddressAccountInfo info = service.getAddressInfo(ip);
+        assertEquals(List.of(player), info.getAccounts());
+        assertEquals(1, info.getAccountInfo(player).getLogins());
+    }
+
+    @Test
+    void getLoginCountIncrementsAcrossRepeatedLogins() throws UnknownHostException {
+        UUID player = UUID.randomUUID();
+        InetAddress ip = address("10.1.0.5");
+
+        service.saveLogin(player, ip);
+        service.saveLogin(player, ip);
+
+        assertEquals(2, service.getLoginCount(player, ip));
+    }
+
+    @Test
+    void getLoginCountIsZeroWhenNoRecordExists() throws UnknownHostException {
+        assertEquals(0, service.getLoginCount(UUID.randomUUID(), address("10.1.0.9")));
+    }
+
+    @Test
+    void getAccountInfoReturnsAddressesUsedByPlayer() throws UnknownHostException {
+        UUID player = UUID.randomUUID();
+        InetAddress ip = address("172.20.0.1");
+
+        service.saveLogin(player, ip);
+
+        AccountAddressInfo info = service.getAccountInfo(player);
+        assertEquals(List.of(ip), info.getAddresses());
+    }
+
+    @Test
+    void getPotentialAltsReturnsAccountsSharingAnAddress() throws UnknownHostException {
+        UUID owner = UUID.randomUUID();
+        UUID alt = UUID.randomUUID();
+        UUID unrelated = UUID.randomUUID();
+        InetAddress sharedIp = address("192.168.50.100");
+        InetAddress otherIp = address("192.168.50.200");
+
+        service.saveLogin(owner, sharedIp);
+        service.saveLogin(alt, sharedIp);
+        service.saveLogin(unrelated, otherIp);
+
+        assertEquals(List.of(alt), service.getPotentialAlts(owner));
+    }
+
+    @Test
+    void getPotentialAltsIsEmptyWhenNoAddressIsShared() throws UnknownHostException {
+        UUID player = UUID.randomUUID();
+        service.saveLogin(player, address("203.0.113.9"));
+
+        assertTrue(service.getPotentialAlts(player).isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary

- Stage B (unit-test expansion) cycle: `LoginService` is the actual public API surface `AafAccountsCommand`, `AafAltsCommand`, and `PlayerJoinListener` depend on (via `AlternateAccountFinder.getLoginService()`), but it had zero test coverage — even after `LoginRepository` gained coverage in #72, the thin service layer wrapping it remained untested.
- Adds `LoginServiceTest`, mirroring `LoginRepositoryTest`'s established pattern: a uniquely-named `jdbc:h2:mem:` database per test, real Flyway migrations, and a real `IpEncryption` instance — no mocks, matching the project's stated testing convention.
- Coverage added: `saveLogin` + `getAddressInfo`, `getLoginCount` (increment-on-repeat-login and the zero/no-record case), `getAccountInfo`, and `getPotentialAlts` (both the shared-address case and the no-shared-address case), all driven through `LoginService` rather than `LoginRepository` directly.

## Triage notes

Both currently open issues were out of scope for this cycle and are left untouched:
- **#62** — `.github/copilot-instructions.md` doc drift: editing agent-loaded config requires separate, explicit human authorization per the dev-loop skill's rules, so it was not touched autonomously (consistent with the note already on that issue from a prior cycle).
- **#47** — Encryption epic: already flagged as resolved by its closed sub-issues, left open pending a human decision on further scope.

No other doc/test gaps were found; this is a test-only change with no production code modified.

## Test plan

- [x] `./gradlew compileJava compileTestJava test` — BUILD SUCCESSFUL, all tests (including the 6 new `LoginServiceTest` cases) pass.
- [x] No production code changed.

<!-- gardener-tend-dispatch -->