### PR TITLE
Suggest only online players in /aaf alts tab-completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - The "You do not have permission to use this command." message from `/aaf accounts` and `/aaf alts` is now red, like every other error message those commands send (see [#75](https://github.com/Dans-Plugins/AlternateAccountFinder/issues/75)).
+- `/aaf alts` tab-completion now suggests only online players instead of every account the server has cached data for. On a long-lived server that offline list can number in the tens of thousands, and Bukkit builds an `OfflinePlayer` for each one on every keystroke; a moderator checking an offline account can still type its full name (see [#76](https://github.com/Dans-Plugins/AlternateAccountFinder/issues/76)).
 
 ### Fixed
 

--- a/src/main/java/com/dansplugins/detectionsystem/commands/AafAltsCommand.java
+++ b/src/main/java/com/dansplugins/detectionsystem/commands/AafAltsCommand.java
@@ -11,6 +11,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
 
 import java.util.Arrays;
 import java.util.List;
@@ -73,10 +74,12 @@ public final class AafAltsCommand implements CommandExecutor, TabCompleter {
         if (args.length > 1) {
             return List.of();
         }
-        // Names are collected before filtering because an account the server has no cached name
-        // for yields null here; PlayerNames skips those instead of throwing (see issue #74).
-        List<String> names = Arrays.stream(plugin.getServer().getOfflinePlayers())
-                .map(OfflinePlayer::getName)
+        // Suggests only online players rather than every OfflinePlayer the server has cached data
+        // for: on a long-lived server that list can be tens of thousands of entries, and
+        // Server#getOfflinePlayers() walks all of them on the main thread on every keystroke (see
+        // issue #76). A moderator checking an offline account can still type its full name.
+        List<String> names = plugin.getServer().getOnlinePlayers().stream()
+                .map(Player::getName)
                 .toList();
         return PlayerNames.matchingNames(names, args.length == 0 ? "" : args[0]);
     }


### PR DESCRIPTION
## Summary
- `AafAltsCommand.onTabComplete` called `Server#getOfflinePlayers()`, which enumerates every account the server has cached data for and constructs an `OfflinePlayer` for each. On a long-lived server that list can be tens of thousands of entries, and tab-completion runs on the main thread on every keystroke, causing a per-keystroke stall.
- Switched the completer to suggest online players (`Server#getOnlinePlayers()`) instead — the practical target of an alt check is usually someone currently connected. A moderator can still type the full name of an offline account.
- This does not change what is suggested for `/aaf accounts`, which already suggests nothing (see #64), and does not touch the IP-disclosure concern from #44/#64 — only names are ever suggested, same as before.
- Added a `CHANGELOG.md` entry under `[Unreleased] / Changed`.

Closes #76

## Skipped this cycle
- #62 (`.github/copilot-instructions.md` drift) — editing agent-loaded config requires explicit human authorization per the alternateaccountfinder-dev-loop skill; already flagged with a comment on the issue.
- #47 (Encryption epic) — left open pending human confirmation that no further encryption work (key rotation, backup/restore tooling) is planned; both known sub-issues are closed.

## Test plan
- [x] `./gradlew compileJava`
- [x] `./gradlew test` (existing `PlayerNamesTest` covers the prefix-matching/null-skipping logic reused here; no behavior in `PlayerNames` changed)
- [ ] Manual: on a live server, join with two accounts, run `/aaf alts <player>`, press Tab after `alts ` and confirm only online player names are suggested (no crash, filters by typed prefix case-insensitively). This is Bukkit-runtime behavior the H2/JVM `Build` workflow cannot exercise.